### PR TITLE
missing jshint

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gulp-ng-annotate": "^2.0.0",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-uglify": "^1.2.0",
+    "jshint": "latest",
     "jshint-stylish": "^2.0.1",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"


### PR DESCRIPTION
some gulp tasks not worked.
I added jshint for resolve this problem.
If I npm install without jshint
![wheniintsallnpm](https://cloud.githubusercontent.com/assets/16340911/20386431/ae7a0d9a-accc-11e6-8a1d-bede09d5a726.png)
And run task 'scripts'
![2016-11-17_1352](https://cloud.githubusercontent.com/assets/16340911/20386553/38371e6a-accd-11e6-8bcf-21dc17bde5f9.png)
